### PR TITLE
CI・リリース・Dependabot運用をAndroid専用構成へ整理

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
     open-pull-requests-limit: 15
     reviewers:
       - bvlion
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 15
+    reviewers:
+      - bvlion

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,0 +1,31 @@
+name: Dependabot Approval Auto-merge
+
+on:
+  pull_request_review:
+    types:
+      - submitted
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-auto-merge:
+    if: |
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.review.state == 'approved' &&
+      github.event.review.user.login == github.repository_owner &&
+      github.repository == 'bvlion/DAIgoAPP'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Enable GitHub auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          if [ "$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest != null')" = "true" ]; then
+            echo "Auto-merge is already enabled for $PR_URL"
+            exit 0
+          fi
+          gh pr merge --auto --merge "$PR_URL"

--- a/.github/workflows/listing.yaml
+++ b/.github/workflows/listing.yaml
@@ -15,10 +15,10 @@ jobs:
   listing:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: '17'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,6 +9,9 @@ on:
       - 'app/**.xml'
       - 'app/proguard-rules.pro'
       - '**.gradle.kts'
+      - 'gradle/libs.versions.toml'
+      - 'gradle.properties'
+      - 'gradle/wrapper/gradle-wrapper.properties'
       - '.github/workflows/main.yaml'
 
 env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,18 +24,18 @@ jobs:
   apk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: '17'
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v6
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', 'gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
 

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -1,33 +1,45 @@
-name: dependabot PR CI
+name: PR CI
 
 on:
   pull_request:
     branches:
       - 'main'
+    paths:
+      - '**.kt'
+      - '**.kts'
+      - '**.xml'
+      - '**.properties'
+      - 'gradle/libs.versions.toml'
+      - '.github/workflows/**'
   workflow_dispatch:
 
 jobs:
-  dependabot:
+  build-and-test:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: '17'
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v6
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', 'gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
 
       - name: Set config files
         run: echo ${{ secrets.DEBUG_GOOGLE_SERVICES_JSON }} | base64 -d > app/src/debug/google-services.json
+
+      - name: Run Android debug build
+        run: ./gradlew :app:assembleDebug
+
+      - name: Run Android unit test
+        run: ./gradlew :app:testDebugUnitTest
 
       - name: Enable KVM group perms
         run: |
@@ -35,10 +47,7 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Run Android unit Test
-        run: ./gradlew :app:testDebugUnitTest
-
-      - name: Run Android UI Test
+      - name: Run Android instrumentation test
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 32
@@ -48,8 +57,8 @@ jobs:
           disable-animations: false
           script: ./gradlew :app:connectedCheck
 
-      - name: Upload UI test report
-        uses: actions/upload-artifact@v2
+      - name: Upload instrumentation test report
+        uses: actions/upload-artifact@v7
         with:
           name: instrumentation_test_report
           path: app/build/reports/androidTests/connected/debug/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,18 +18,18 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: '17'
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v6
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', 'gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
 


### PR DESCRIPTION
## Summary

Closes #170

CI・release・Dependabot運用を、Android専用構成後の現状(`app` moduleのみ)に合わせて現行化しました。参考として `bvlion/WearLink` の現在の main (`.github/dependabot.yml` / `pr-ci.yaml` / `dependabot-auto-merge.yaml`) を確認し、DAIgoAPPの既存の配布方法・テスト・モジュール構成に必要な部分のみを取り入れています。

## 変更内容

### 1. PR CI (`pr-test.yaml` → `pr-ci.yaml`)

- Dependabot専用(`if: github.actor == 'dependabot[bot]' ...`)を廃止し、`main` への通常のPull Requestすべてで実行されるようにしました。Claude Code等が作成する通常PRもCIで検証されます。
- `on.pull_request.paths` を `**.kt` / `**.kts` / `**.xml` / `**.properties` / `gradle/libs.versions.toml` / `.github/workflows/**` へ整理し、Kotlin・XML・Gradle・Version Catalog・GitHub Actions自身の変更を取りこぼさないようにしました。
- 検証項目として `./gradlew :app:assembleDebug`(debug build)と `./gradlew :app:testDebugUnitTest`(unit test)を明示的なstepとして追加しました。
- 既存の instrumentation test(`./gradlew :app:connectedCheck` + `reactivecircus/android-emulator-runner`)はCI時間削減のために削除せず維持しています。現行のKVM有効化手順・api-level 32構成のまま合理的に動作すると判断しました。
- KMP時代の `shared` / `androidApp` / `:shared:testDebugUnitTest` 等の参照は元々このファイルに存在せず、今回も残していません。

### 2. GitHub Actionsの現行化

作業時点(2026-08-15)で各Actionの現行安定major versionを確認し、`main.yaml` / `release.yaml` / `listing.yaml` / `pr-ci.yaml` を更新しました。

| Action | 旧 | 新 |
|---|---|---|
| actions/checkout | v3 / v4 | v7 |
| actions/setup-java | v3 | v5 |
| actions/cache | v1 (deprecated) | v6 |
| actions/upload-artifact | v2 (deprecated) | v7 |

あわせて、deprecatedだった `actions/cache@v1` と `actions/upload-artifact@v2` は完全に解消しています。

Gradleキャッシュキーの `hashFiles('**/*.gradle')` は、現在プロジェクトがKotlin DSL (`*.gradle.kts`) とVersion Catalogのみを使用しているため実質的に変化せずキャッシュが陳腐化するバグがあったので、`hashFiles('**/*.gradle*', 'gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties')` に修正しました(`main.yaml` / `release.yaml` / `pr-ci.yaml`)。

### 3. main branch CI (`main.yaml`)

役割・trigger種別(mainへのpush → release build → Firebase App Distribution)は変更していません。Actionsバージョンとキャッシュキーに加え、`on.push.paths` を現行のVersion Catalog構成に追従させました。

Dependabotが `gradle/libs.versions.toml` のみを変更したPRをmainへmergeした場合でも、既存の `**.gradle.kts` 等のpaths条件だけでは main branch CI が発火しないため、以下をpaths対象へ追加しています。

- `gradle/libs.versions.toml`
- `gradle.properties`
- `gradle/wrapper/gradle-wrapper.properties`

既存Secretsからの `google-services.json` 生成、signingConfigs、Firebase App Distribution設定はそのままです。`app/build.gradle.kts` の `proguard-android-optimize.txt`(#169対応)にも変更はありません。

### 4. release workflow (`release.yaml`)

役割・trigger(GitHub Release published → `bundleRelease` → Google Play Publisherによる `publishBundle`)は変更していません。Actionsバージョンとキャッシュキーのみ更新しました。

### 5. listing workflow (`listing.yaml`)

役割・trigger(Play Store listing変更 → `publishListing`)は変更していません。`actions/checkout` / `actions/setup-java` のバージョンのみ更新しました(このworkflowはGradleキャッシュを元々使用していません)。

### 6. Dependabot (`.github/dependabot.yml`)

既存の `gradle` エコシステム(directory `/`, daily 09:00 Asia/Tokyo, open-pull-requests-limit 15, reviewers: bvlion)は変更せず、`github-actions` エコシステムを同条件で追加しました。

### 7. Dependabot auto-merge (`dependabot-auto-merge.yaml` 新規)

WearLinkの `dependabot-auto-merge.yaml` を参考に追加しました。以下をすべて満たした場合のみ発火します。

- PR作成者が `dependabot[bot]`
- レビューの `state` が `approved`
- レビュアーが `github.repository_owner`(=リポジトリオーナー)
- `github.repository` が `bvlion/DAIgoAPP`

条件を満たした場合、`gh pr view --json autoMergeRequest` で既に auto-merge が有効かを確認し、有効であれば何もせず終了(idempotent)、未有効であれば `gh pr merge --auto --merge` でGitHubのauto-mergeを有効化するだけです。auto approveは追加していません。通常PRを対象にする仕組みでもありません。

## Repository Settings (Allow auto-merge) について

現在の `bvlion/DAIgoAPP` の Repository Settings は `allow_auto_merge: false` です(`gh api repos/bvlion/DAIgoAPP` で確認)。今回の作業ではリポジトリ設定は変更していません。

`dependabot-auto-merge.yaml` が実際に機能するには、GitHubの **Settings → General → Pull Requests → Allow auto-merge** を有効にする必要があります。このPRをmergeし、Dependabot PRの自動mergeを使い始めるタイミングまでに、ユーザー(リポジトリオーナー)がGitHub UI上で有効化してください。branch protectionの必須チェック(`required_status_checks.contexts`)は現状空のため、その点も含めて運用方針に応じて別途ご確認ください。

## 検証

- `git diff --check`: 成功
- ワークフローYAML構文チェック(`yaml.safe_load`): `main.yaml` / `release.yaml` / `listing.yaml` / `pr-ci.yaml` / `dependabot-auto-merge.yaml` / `dependabot.yml` すべてOK
- `.github` 配下に `shared` / `androidApp` / `iOS` / `:shared:testDebugUnitTest` 等の旧構成参照が残っていないことをgrepで確認
- `./gradlew :app:assembleDebug`: 成功
- `./gradlew :app:testDebugUnitTest`: 成功
- `./gradlew :app:connectedCheck` (ローカル接続エミュレータで実施): CI相当の `Pixel 3a XL` (通常のphoneプロファイル)では `failures=0` で成功。ローカルにたまたま接続されていた `Wear OS` 用エミュレータ(CIの `pixel` プロファイルとは無関係な端末)側でのみ失敗しましたが、これはCI設定と無関係なローカル環境固有の事象であり、今回の変更によるものではありません。

## 実行できなかった検証

- release workflow (`release.yaml`) 本番相当の実行:署名鍵・Google Play service account JSON等の本番Secretsがローカルに存在しないため、`bundleRelease` / `publishBundle` の実機検証は行っていません。YAML構文とAction/キャッシュ設定の整合性確認に留めています。
- `pr-ci.yaml` / `main.yaml` の実際のGitHub Actions上での実行結果(このPR自体のCI結果)は、PR作成後にGitHub上でご確認ください。

## 対象外(今回実施していません)

- 古いKMP/iOS/Ktor時代のDependabot PRのclose・merge(Issue本文の指示通り、今回は行っていません)
- Repository Settings (`Allow auto-merge` 等) の変更
- 通常PRの自動merge・自動approve
- applicationId / namespace / API仕様 / UI仕様 / versionCode / versionName等アプリ本体仕様の変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)
