### PR TITLE
README・AGENTS.md・CLAUDE.mdをAndroid専用構成に合わせて整備

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# Repository Guidelines
+
+## プロジェクト概要
+
+DAIgoAPPはAndroidスマートフォン専用アプリで、application moduleは `app/` のみです。
+
+- Jetpack Compose
+- Retrofit / OkHttp / kotlinx.serialization
+- Room / DataStore
+- Firebase Analytics / Firebase Crashlytics
+- Java 17、リポジトリ同梱のGradle Wrapper
+
+backendは [bvlion/DAIgoAPI2](https://github.com/bvlion/DAIgoAPI2) です。
+
+## 変更方針
+
+- Issueで依頼された範囲の解決に必要な最小限の差分にしてください。
+- 無関係なリファクタリング、命名変更、一括整形、dependency updateを混ぜないでください。
+- 挙動を推測だけで変更せず、既存の実装・呼び出し元・テスト・GitHub Actions workflowを確認してください。
+- DAIgoAPPの規模に対して不要なlayer / abstractionを追加しないでください。
+- Android専用構成のため、明示的な要件がない限りKMP / iOS構成を再導入しないでください。
+- AdMob / Google Mobile Ads SDK、Firebase App Distributionは撤去済みです。「以前あったから」という理由で再導入しないでください。
+
+## コーディング / 依存管理
+
+DAIgoAPPには現時点で `.editorconfig` が存在しません。存在しないファイルへの準拠を前提にせず、Kotlin / Gradle Kotlin DSLの既存styleを確認して維持してください（現行コードは2-space indentation）。変更対象外のコードを機械的に一括整形しないでください。
+
+dependency versionは原則として `gradle/libs.versions.toml` で管理します。HTTP通信は既存のRetrofit / OkHttp / kotlinx.serialization構成を優先してください。
+
+## ビルドとテスト
+
+代表的なコマンド:
+
+- `./gradlew :app:assembleDebug`
+- `./gradlew :app:testDebugUnitTest`
+- `./gradlew :app:connectedCheck`（端末またはエミュレーターが必要）
+- `git diff --check`
+
+すべての変更で全コマンドの実行を必須とはしません。変更範囲に対応する最小限かつ十分な検証を行ってください。
+
+検証を実行できなかった場合、または失敗した場合は成功として扱わず、実行したコマンドと未実施・失敗の理由をPull Request本文に記載してください。
+
+DAIgoAPPはスマートフォン専用です。ローカル環境にWear OS emulator等の対象外端末が同時接続されており、その端末だけでinstrumentation testが失敗した場合は、対象phone端末やCI環境との差異を確認してください。その失敗を回避するためにアプリ仕様を変更しないでください。
+
+## 秘密情報とローカル設定
+
+- 新しい秘密値・API token・password・service account JSONをコミットしないでください。
+- `google-services.json` / `google-play-service.json` / `.envrc` は既存の`.gitignore`の扱いを維持してください。
+- 必要な秘密情報が環境にない場合、ダミー値のコミットや設定の迂回でbuildを通さず、未検証として報告してください。
+- release signingの検証に必要な環境がない場合は未検証として報告してください。
+- `release.keystore` は既にリポジトリで管理されている署名ファイルです。明示的な依頼がない限り削除・置換・ローテーションしないでください。
+
+## Git / Pull Request
+
+- `main`へ直接commit / pushしないでください。
+- force push等の破壊的操作を行わないでください。
+- Issue対応では専用branchを使用してください。branch名は現在使われている `feature/issue-<issue番号>-<short-task>` 系を基本とします。
+- 調査 → 実装 → 検証 → commit → push → Ready for reviewのPR作成、まで行ってください。
+- PR本文には `Closes #<issue>`、目的、変更内容、最終的な検証結果、未検証事項を記載してください。
+- 解消済みの試行錯誤を大量にPR本文へ残さないでください。
+- ユーザーの承認なしに通常のPRをmergeしないでください。
+- Issueを手動でcloseしないでください。
+- Dependabot PRを自動Approveしないでください。Dependabot PRのauto-mergeは、repository ownerによるApprove、repositoryのauto-merge設定、CI / branch protection等の条件をすべて満たす場合にのみ有効になります。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -3,17 +3,52 @@ D◯I 語 Client
 
 <a href='https://play.google.com/store/apps/details?id=net.ambitious.daigoapp.android&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Google Play で手に入れよう' width=300 src='https://play.google.com/intl/ja/badges/static/images/badges/ja_badge_web_generic.png'/></a>
 
+## 概要
+
+- Androidスマートフォン専用アプリ
+- application moduleは `app/` のみ
+- backendは [bvlion/DAIgoAPI2](https://github.com/bvlion/DAIgoAPI2)
+
 ## 開発環境
 
-* Java 1７
+* Java 17
 * Android Studio
-* server 環境
-  * [DAIgoAPI](https://github.com/bvlion/DAIgoAPI) を実行する
+* リポジトリ同梱のGradle Wrapper
 
-## 配信環境
+## Backend / ローカル開発
 
-* master にマージすると GitHub Actions で APK が App Distribution に配信される
-* v タグを切ることで本番デプロイが行われる
+backendは [bvlion/DAIgoAPI2](https://github.com/bvlion/DAIgoAPI2)（PHP / Slim4）です。ローカルではDAIgoAPI2リポジトリで以下を実行して起動します（詳細はDAIgoAPI2のREADMEを参照）。
+
+```
+docker compose up composer
+docker compose up slim -d
+```
+
+DAIgoAPP側は `HOST` / `BEARER` を環境変数からGradle経由で`BuildConfig`へ渡します。`HOST`が空の場合、Android emulatorからのアクセスを想定し `http://10.0.2.2:8080` を使用します（`ApiClient.resolveHost`）。値そのものは各自のローカル環境（`.envrc`等）で用意してください。
+
+## Build / Test
+
+* `./gradlew :app:assembleDebug`
+* `./gradlew :app:testDebugUnitTest`
+* `./gradlew :app:connectedCheck`（端末またはエミュレーターが必要）
+
+release buildは署名用環境変数と後述の`release.keystore`が必要なため、通常は後述のCIから実行します。
+
+## CI / 配布
+
+* PR: `main`向けPull Requestで対象ファイル（`.kt` / `.kts` / `.xml` / `.properties` / `gradle/libs.versions.toml` / `.github/workflows/**`）が変更されると [`pr-ci.yaml`](.github/workflows/pr-ci.yaml) がdebug build・unit test・instrumentation testを実行します。
+* 本番配信: GitHub Releaseが`published`になると [`release.yaml`](.github/workflows/release.yaml) が`bundleRelease`と`publishBundle`（Google Play `production` track）を実行します。
+* Play Store掲載情報: listing対象ファイル（`app/src/main/play/listings/ja-JP/**`）が`main`へpushされると [`listing.yaml`](.github/workflows/listing.yaml) が`publishListing`を実行します。
+
+## 秘密情報・設定ファイル
+
+以下はリポジトリに含めず、各自の環境で用意します（`.gitignore`で除外済み）。
+
+* `google-services.json`
+* `google-play-service.json`
+* `.envrc`（ローカルの`HOST` / `BEARER`等）
+
+release buildの署名には`KEYSTORE_ALIAS` / `KEYSTORE_PASSWORD`等の環境変数が必要です。`release.keystore`は既存の署名ファイルとしてリポジトリで管理されています。新しい秘密値・資格情報はコミットしないでください。
 
 ## キー管理
 各ファイル Notion にて管理中


### PR DESCRIPTION
Closes #171

## 目的

DAIgoAPPは #167〜#170 でAndroid単体構成へ移行し、#177/#178でAdMob、#179/#180でFirebase App Distributionを撤去済みだが、README.mdには旧 `master` ブランチ、旧backend `DAIgoAPI`、Firebase App Distribution、`v`タグ本番配信などの古い記述が残っていた。現在の実態に合わせてREADMEを現行化し、AIエージェント（Claude Code / Codex等）がIssue対応時に迷わないよう `AGENTS.md` を新設、`CLAUDE.md` からそれをimportする構成にした。

## 変更内容

### README.md

- プロジェクト概要をAndroidスマートフォン専用アプリ・`app/`単一module・backend = [bvlion/DAIgoAPI2](https://github.com/bvlion/DAIgoAPI2)に更新（旧`bvlion/DAIgoAPI`リンクを置き換え）
- 開発環境をJava 17 / Android Studio / 同梱Gradle Wrapperに整理
- backend/ローカル開発: DAIgoAPI2のREADME実物（`docker compose up composer` → `docker compose up slim -d`）とDAIgoAPPの`HOST`/`BEARER`環境変数、`ApiClient.resolveHost`によるemulatorデフォルト`http://10.0.2.2:8080`を説明（値は非掲載）
- build/testの代表コマンド（`:app:assembleDebug` / `:app:testDebugUnitTest` / `:app:connectedCheck`）を記載
- CI/配布を実物のworkflow（`pr-ci.yaml` / `release.yaml` / `listing.yaml`）に合わせて更新し、旧`master`・Firebase App Distribution・`v`タグ本番配信の記述を削除
- 秘密情報・設定ファイル（`google-services.json` / `google-play-service.json` / `.envrc` / `HOST` / `BEARER` / release signing環境変数）の扱いを値なしで説明。`release.keystore`は既存trackedファイルとして扱いを変更せず、削除・置換・ローテーションの説明も追加していない
- Notion（キー管理）・Google Spreadsheet（お問い合わせ）の既存記述はリポジトリから実態を検証できないため、推測で更新せずそのまま維持

### AGENTS.md（新規）

DAIgoAPPの実物（`app/`単一module、Jetpack Compose、Retrofit/OkHttp/kotlinx.serialization、Room/DataStore、Firebase Analytics/Crashlytics、Java 17、Gradle Wrapper）に基づき、以下を明文化:

- 変更方針（最小差分、無関係なリファクタ/整形/依存更新を混ぜない、AdMob・Firebase App Distributionを理由なく再導入しない等）
- コーディング/依存管理（`.editorconfig`が存在しない前提で既存styleを維持、`gradle/libs.versions.toml`でのバージョン管理）
- build/test代表コマンドと「変更範囲に対応する最小限かつ十分な検証」方針、対象外端末（Wear OS等）の失敗でアプリ仕様を変更しない旨
- 秘密情報の扱い（新規秘密値をコミットしない、`release.keystore`を勝手に削除・置換・ローテーションしない）
- Git/PR運用（`feature/issue-<番号>-<short-task>`ブランチ、Ready for reviewまで実施、`Closes #<issue>`記載、Dependabot自動Approve禁止、auto-mergeはowner Approve + repository設定 + CI/branch protectionを満たす場合のみ、という条件付き説明）

WearLink固有のmobile/wear/shared構成・Wear OS・Data Layer・Horologist・worktree script・`agent/...`ブランチ命名はコピーしていません。

### CLAUDE.md（新規）

```md
@AGENTS.md
```

のみとし、共通ルールをAGENTS.mdへ一本化。READMEやAGENTS.mdの一般ルールをCLAUDE.mdへ複製していません。

## 対象外（変更していないこと）

- Kotlin/Javaコード、AndroidManifest、Gradle構成、dependency version
- GitHub Actions、Dependabot設定、Repository Settings
- AdMob / Firebase App Distributionの再導入
- `release.keystore`（削除・置換・ローテーションなし）
- Repository Secrets、秘密値そのもの（差分に含まれていないことを確認済み）

## 検証結果

- `git diff --check`: エラーなし
- `./gradlew :app:assembleDebug --dry-run` / `:app:testDebugUnitTest --dry-run` / `:app:connectedCheck --dry-run`: すべてBUILD SUCCESSFULでタスクが実在することを確認
- `./gradlew :app:assembleDebug`: BUILD SUCCESSFUL（ローカルの `app/src/debug/google-services.json` 等を利用、up-to-date）
- `./gradlew :app:testDebugUnitTest`: BUILD SUCCESSFUL
- `./gradlew :app:connectedCheck`: 未実施（ドキュメントのみの変更検証には不要と判断し、実機/エミュレーター接続状態への依存を避けるため未実行）
- README/AGENTS.mdのリンク・コマンド・workflow説明が現在のyaml実物（`pr-ci.yaml` / `release.yaml` / `listing.yaml`）と一致することを目視確認
- backend説明はDAIgoAPI2のREADME実物と一致することを確認
- 旧`master`・旧backend`DAIgoAPI`・Firebase App Distribution・AdMob・WearLink固有記述（mobile/wear/shared/Data Layer/worktree）・存在しない`.editorconfig`前提の記述が残っていないことを確認
- `CLAUDE.md`が`@AGENTS.md`をimportしていることを確認
- secret値そのものが差分に含まれていないことを確認

## PR CIについて

現在の `.github/workflows/pr-ci.yaml` は `paths` が `**.kt` / `**.kts` / `**.xml` / `**.properties` / `gradle/libs.versions.toml` / `.github/workflows/**` のみを対象としており、README.md/AGENTS.md/CLAUDE.mdのみの変更はこのpaths対象外です。そのため本PRではPR CIが起動しない可能性があります（本Issueのためだけにpathsは変更していません）。

## 未検証事項

- `:app:connectedCheck`（instrumentation test）は未実施
- Notion（キー管理）・Google Spreadsheetの外部サービス側の実態は未確認（リポジトリから検証不能なため記述は維持のみ）

通常のPRです。auto-mergeはせず、レビュー・承認をお待ちします。