### PR TITLE
1.0.4リリース向けにversionCode / versionNameを更新

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
   defaultConfig {
     minSdk = 26
     targetSdk = 37
-    versionCode = 8
-    versionName = "1.0.3"
+    versionCode = 9
+    versionName = "1.0.4"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     vectorDrawables {


### PR DESCRIPTION
## 目的

AdMob撤去・Android専用構成への整理後の現在のmainを、次回Google Play productionへリリース可能なversionへ更新します。

Closes #182

## 変更内容

`app/build.gradle.kts` のversionのみ変更しました。

- `versionCode`: 8 → 9
- `versionName`: "1.0.3" → "1.0.4"

version以外のアプリ設定（applicationId / namespace / minSdk・targetSdk・compileSdk / dependency version / Gradle plugin version / signing設定 / proguard設定 / HOST・BEARER / Firebase Analytics・Crashlytics / Google Play Publisher設定 / release track / AGENTS.md / CLAUDE.md / README.md 等）は変更していません。

AdMob / Firebase App Distributionは現在のmainで撤去済みであることを確認済みで、本PRで再導入していません。

GitHub Releaseの作成・publish、`publishBundle`、Google Play productionへの公開、Play Consoleの広告申告変更は本PRでは実施していません。production release自体はこのPRのmerge後にユーザー側で別工程として行います。

## 検証結果

- `git diff --check`: 差分なし（問題なし）
- `./gradlew :app:assembleDebug`: BUILD SUCCESSFUL
- `./gradlew :app:testDebugUnitTest`: BUILD SUCCESSFUL
- `./gradlew :app:bundleRelease`: BUILD SUCCESSFUL（ローカルに release.keystore・release用google-services.json・KEYSTORE_ALIAS/KEYSTORE_PASSWORDが揃っていたため実施）
- PR CI: PR作成後に確認します

## 未検証事項

- `publishBundle` / Google Play production公開: 本Issueの対象外のため未実施
- release署名済みAABの実機・実端末での動作確認: 未実施（ビルド成功の確認のみ）
