### PR TITLE
Slack通知を公式slack-github-actionへ移行

### DIFF
--- a/.github/workflows/listing.yaml
+++ b/.github/workflows/listing.yaml
@@ -30,13 +30,10 @@ jobs:
         run: ./gradlew publishListing
 
       - name: Notify Slack
-        uses: 8398a7/action-slack@v3
+        uses: slackapi/slack-github-action@v4.0.0
         with:
-          status: ${{ job.status }}
-          fields: repo,message,commit,author,action,eventName,ref,workflow # selectable (default: repo,message)
-          username: GHA_LISTING
-          icon_emoji: ':smiling_face_with_3_hearts:'
-          channel: '#略語generator'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "DAIgoAPP listing: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         if: always()

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,13 +44,10 @@ jobs:
         run: ./gradlew publishBundle
 
       - name: Notify Slack
-        uses: 8398a7/action-slack@v3
+        uses: slackapi/slack-github-action@v4.0.0
         with:
-          status: ${{ job.status }}
-          fields: repo,message,commit,author,action,eventName,ref,workflow # selectable (default: repo,message)
-          username: GHA_RELEASE
-          icon_emoji: ':sunglasses:'
-          channel: '#略語generator'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "DAIgoAPP release: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         if: always()


### PR DESCRIPTION
## 概要

Closes #184

`release.yaml` / `listing.yaml` の Notify Slack ステップを、非公式の `8398a7/action-slack@v3` から Slack公式の `slackapi/slack-github-action@v4.0.0` (Incoming Webhook方式) へ移行しました。

## 背景

1.0.4 release workflow ([Run 32040095519](https://github.com/bvlion/DAIgoAPP/actions/runs/32040095519) / [Job](https://github.com/bvlion/DAIgoAPP/actions/runs/32040095519/job/95539962512)) で、Google Playへのpublish自体は成功したものの、最後のNotify SlackがHTTP 404で失敗していました。あわせてNode.js 20 deprecation警告も出ていました。

## 変更内容

- `.github/workflows/release.yaml`
  - `8398a7/action-slack@v3` と `status` / `fields` / `username` / `icon_emoji` / `channel` / env経由の `SLACK_WEBHOOK_URL` を撤去
  - `slackapi/slack-github-action@v4.0.0` の `webhook` / `webhook-type: incoming-webhook` / `payload` 形式へ置き換え
  - 通知本文に DAIgoAPP release であること・`job.status`・当該Actions RunへのURLを含める
  - `if: always()` は維持（release成功/失敗どちらでも通知を試みる）
- `.github/workflows/listing.yaml`
  - 同様の方針で移行（本文は listing 向けに変更）
  - `if: always()` は維持

Incoming Webhook方式・Secret名 `SLACK_WEBHOOK_URL` は変更していません。release/listing本体の処理（`bundleRelease` / `publishBundle` / `publishListing` など）やtriggerも変更していません。

## 参照した公式情報

- Slack公式ドキュメント: https://docs.slack.dev/tools/slack-github-action/sending-data-slack-incoming-webhook/
  - Incoming Webhook方式では `uses: slackapi/slack-github-action@v4.0.0`、`with.webhook` / `with.webhook-type: incoming-webhook` / `with.payload`（`|` によるYAML/文字列形式、例: `text: "..."`）が案内されていることを確認
- `slackapi/slack-github-action` の現在のGitHub Release: `v4.0.0` が最新 (2026-07-15)

## 検証結果

- `git diff --check`: 差分なし（問題なし）
- YAML妥当性: `python3 -c "import yaml; yaml.safe_load(...)"` で `release.yaml` / `listing.yaml` ともにパース成功
- `grep -rn "8398a7" .github/workflows/`: repository内のworkflowから該当なし
- `slackapi/slack-github-action@v4.0.0` を使用していることを確認
- `SLACK_WEBHOOK_URL` はSecret参照のまま維持
- release/listing双方で `if: always()` を維持
- release/listingの本体処理（bundleRelease / publishBundle / publishListing）・triggerに変更なし
- PR CI: 本PR作成後の結果を確認（下記コメントまたはChecksタブ参照）

## 未検証事項

- Slackへの実送信は未検証です。今回発生していたHTTP 404の原因がWebhook URL自体の失効である可能性があるため、SLACK_WEBHOOK_URLの状態確認・必要なら再発行はユーザー側で行い、次回実際のrelease/listing workflow実行時に確認します。
- 実際のrelease/listing workflow実行（GitHub Release作成、Google Play production再publish、listing publish）は本Issueの検証目的では行っていません。

## 対象外（変更していないもの）

release/listing workflowのtrigger、bundleRelease、publishBundle、publishListing、Google Play Publisher設定、production track、versionCode/versionName、applicationId/namespace、Gradle設定、dependency、Firebase、signing設定、HOST/BEARER、Dependabot、PR CI仕様、README.md、AGENTS.md、CLAUDE.md、release-notes、listing内容

## 既知の懸念点

- 移行後もHTTP 404の根本原因（Webhook URL失効の可能性）が解消されているかは、本PRのCIだけでは確認できません。次回実際のrelease/listing実行時にSlack通知の到達を確認する必要があります。