### PR TITLE
広告削除後のメイン画面上部レイアウトとSystem Bar表示を修正

### DIFF
--- a/app/src/main/java/net/ambitious/daigoapp/android/MainActivity.kt
+++ b/app/src/main/java/net/ambitious/daigoapp/android/MainActivity.kt
@@ -1,10 +1,13 @@
 package net.ambitious.daigoapp.android
 
 import android.content.res.Configuration
+import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -47,68 +50,88 @@ class MainActivity : ComponentActivity() {
 
       val scope = rememberCoroutineScope()
 
-      AppTheme(when (viewMode.value) {
+      val useDarkTheme = when (viewMode.value) {
         AppDataStore.ViewMode.DEFAULT -> isSystemInDarkTheme()
         AppDataStore.ViewMode.LIGHT -> false
         AppDataStore.ViewMode.DARK -> true
-      }) {
+      }
+
+      DisposableEffect(useDarkTheme) {
+        enableEdgeToEdge(
+          statusBarStyle = SystemBarStyle.auto(
+            Color.TRANSPARENT,
+            Color.TRANSPARENT,
+          ) { useDarkTheme },
+          navigationBarStyle = SystemBarStyle.auto(
+            Color.TRANSPARENT,
+            Color.TRANSPARENT,
+          ) { useDarkTheme },
+        )
+        onDispose {}
+      }
+
+      AppTheme(useDarkTheme) {
         Surface(
-          modifier = Modifier
-            .fillMaxSize()
-            .windowInsetsPadding(WindowInsets.systemBars),
+          modifier = Modifier.fillMaxSize(),
           color = MaterialTheme.colors.background
         ) {
-          ErrorDialogCompose(viewModel.errorDialog.collectAsState().value) {
-            viewModel.dismissErrorDialog()
-          }
-
-          RulesDialogCompose(rules.value) {
-            viewModel.dismissRules()
-          }
-
-          HistoryDialogCompose(histories.value) {
-            viewModel.setHistoryShow(false)
-          }
-
-          LoadingCompose(loading.value)
-
-          BackHandler(viewModel.resultBottomSheet.isVisible) {
-            scope.launch {
-              viewModel.resultBottomSheet.hide()
+          Box(
+            modifier = Modifier
+              .fillMaxSize()
+              .windowInsetsPadding(WindowInsets.systemBars)
+          ) {
+            ErrorDialogCompose(viewModel.errorDialog.collectAsState().value) {
+              viewModel.dismissErrorDialog()
             }
-          }
 
-          ModalBottomSheetLayout(
-            sheetState = viewModel.resultBottomSheet,
-            sheetShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
-            sheetContent = {
-              if (isMenuShow.value) {
-                MenuCompose(
-                  viewMode.value,
-                  { viewModel.setViewMode(it) },
-                  { viewModel.showRules(it) },
-                  { viewModel.setHistoryShow(true) }
-                )
-              } else {
-                ResultModalCompose(
-                  viewModel.showProposal,
-                  result.value,
-                  input.value,
-                  proposal.value,
-                  { viewModel.setInputWord(it, true) },
-                  { viewModel.proposalButtonClick() }
-                )
+            RulesDialogCompose(rules.value) {
+              viewModel.dismissRules()
+            }
+
+            HistoryDialogCompose(histories.value) {
+              viewModel.setHistoryShow(false)
+            }
+
+            LoadingCompose(loading.value)
+
+            BackHandler(viewModel.resultBottomSheet.isVisible) {
+              scope.launch {
+                viewModel.resultBottomSheet.hide()
               }
             }
-          ) {
-            AllViews(
-              input.value,
-              createButtonEnable.value,
-              words.value,
-              { viewModel.setInputWord(it, false) },
-              { viewModel.buttonClick(scope) },
-              { viewModel.showMenu(scope) }
-            )
+
+            ModalBottomSheetLayout(
+              sheetState = viewModel.resultBottomSheet,
+              sheetShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
+              sheetContent = {
+                if (isMenuShow.value) {
+                  MenuCompose(
+                    viewMode.value,
+                    { viewModel.setViewMode(it) },
+                    { viewModel.showRules(it) },
+                    { viewModel.setHistoryShow(true) }
+                  )
+                } else {
+                  ResultModalCompose(
+                    viewModel.showProposal,
+                    result.value,
+                    input.value,
+                    proposal.value,
+                    { viewModel.setInputWord(it, true) },
+                    { viewModel.proposalButtonClick() }
+                  )
+                }
+              }
+            ) {
+              AllViews(
+                input.value,
+                createButtonEnable.value,
+                words.value,
+                { viewModel.setInputWord(it, false) },
+                { viewModel.buttonClick(scope) },
+                { viewModel.showMenu(scope) }
+              )
+            }
           }
         }
       }
@@ -132,7 +155,7 @@ fun AllViews(
       .verticalScroll(rememberScrollState()),
     verticalArrangement = Arrangement.SpaceBetween
   ) {
-    Column {
+    Column(Modifier.padding(top = 8.dp)) {
         SamplesCompose(onTextChange, words)
         InputCompose(input, createButtonEnable, onTextChange, buttonClick, showMenuClick)
     }

--- a/app/src/main/java/net/ambitious/daigoapp/android/MainActivity.kt
+++ b/app/src/main/java/net/ambitious/daigoapp/android/MainActivity.kt
@@ -1,10 +1,8 @@
 package net.ambitious.daigoapp.android
 
 import android.content.res.Configuration
-import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
-import androidx.activity.SystemBarStyle
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -19,6 +17,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.view.WindowCompat
 import androidx.lifecycle.ViewModelProvider
 import kotlinx.coroutines.launch
 import net.ambitious.daigoapp.android.compose.*
@@ -33,6 +32,7 @@ class MainActivity : ComponentActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    enableEdgeToEdge()
     viewModel = ViewModelProvider(this)[MainViewModel::class.java]
 
     setContent {
@@ -56,18 +56,11 @@ class MainActivity : ComponentActivity() {
         AppDataStore.ViewMode.DARK -> true
       }
 
-      DisposableEffect(useDarkTheme) {
-        enableEdgeToEdge(
-          statusBarStyle = SystemBarStyle.auto(
-            Color.TRANSPARENT,
-            Color.TRANSPARENT,
-          ) { useDarkTheme },
-          navigationBarStyle = SystemBarStyle.auto(
-            Color.TRANSPARENT,
-            Color.TRANSPARENT,
-          ) { useDarkTheme },
-        )
-        onDispose {}
+      SideEffect {
+        WindowCompat.getInsetsController(window, window.decorView).apply {
+          isAppearanceLightStatusBars = !useDarkTheme
+          isAppearanceLightNavigationBars = !useDarkTheme
+        }
       }
 
       AppTheme(useDarkTheme) {
@@ -78,7 +71,7 @@ class MainActivity : ComponentActivity() {
           Box(
             modifier = Modifier
               .fillMaxSize()
-              .windowInsetsPadding(WindowInsets.systemBars)
+              .windowInsetsPadding(WindowInsets.systemBars.union(WindowInsets.displayCutout))
           ) {
             ErrorDialogCompose(viewModel.errorDialog.collectAsState().value) {
               viewModel.dismissErrorDialog()

--- a/app/src/main/java/net/ambitious/daigoapp/android/MainActivity.kt
+++ b/app/src/main/java/net/ambitious/daigoapp/android/MainActivity.kt
@@ -1,8 +1,10 @@
 package net.ambitious.daigoapp.android
 
 import android.content.res.Configuration
+import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -32,7 +34,13 @@ class MainActivity : ComponentActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    enableEdgeToEdge()
+    // API 28以下はnavigationBarStyleのscrim色がOSのdark/light判定のみで決まり、
+    // アプリ内のDEFAULT/LIGHT/DARK(useDarkTheme)と食い違い得るため、
+    // scrimを持たせず透明にしてアプリ自身のbackgroundをそのまま見せる。
+    // icon appearanceはSideEffect側でuseDarkThemeへ同期する。
+    enableEdgeToEdge(
+      navigationBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT)
+    )
     viewModel = ViewModelProvider(this)[MainViewModel::class.java]
 
     setContent {


### PR DESCRIPTION
## Summary

Closes #189

AdMob撤去後のproduction 1.0.4実機確認で見つかった、System Bar表示とメイン画面上部spacingの問題を最小差分で修正します。

## 原因調査結果

- `app/src/main/res/values/themes.xml` の `android:statusBarColor` は、targetSdk 37(API 35+)でedge-to-edgeが強制されるため実効性がなく、システムのデフォルトwindow背景(明るい色)がstatus bar領域に見えていた。
- `MainActivity.kt` の `Surface` に `.windowInsetsPadding(WindowInsets.systemBars)` が直接付いており、Surfaceの背景色(アプリthemeのbackground)がSystem Bar領域まで描画されず、その領域だけ地の背景色が分断されて見えていた。
- status bar / navigation barのicon appearance(明暗)を、アプリ内 `AppDataStore.ViewMode`(DEFAULT/LIGHT/DARK)へ明示的に同期する処理が存在せず、OSのdark/light判定のみに依存していた。
- AdMob撤去で `NativeAdCompose()` が無くなった結果、`AllViews` 内の `Column` に上部paddingが無く、`SamplesCompose` 自身の16.dp paddingのみでSystem Bar直下に詰まって見えていた。
- (レビュー指摘反映)当初の実装は `windowInsetsPadding(WindowInsets.systemBars)` のみで、display cutout(notch / punch-hole)を考慮していなかった。また `enableEdgeToEdge()` をComposeの `DisposableEffect` 内(setContent後)で呼んでおり、古いAndroid versionで初回layoutがedge-to-edge前提で構築されない可能性があった。

## System BarをどのAPI/方針で修正したか

`androidx.activity:activity` 1.13.0(activity-compose経由で解決済み)が提供する `enableEdgeToEdge()` と、`androidx.core:core`(core-ktx経由で解決済み)が提供する `WindowInsetsControllerCompat` を採用しました。Accompanist System UI Controller等の追加dependencyは導入していません。

責務を以下の2つに分離しています。

1. **edge-to-edgeの有効化**: `MainActivity.onCreate()` 内、`super.onCreate()` の直後・`setContent()` より前で `enableEdgeToEdge()` を呼び出し。Jetpack Compose公式ガイド([Set up edge-to-edge](https://developer.android.com/develop/ui/compose/system/setup-e2e))が示す `super.onCreate(savedInstanceState); enableEdgeToEdge(); ...` の構成に合わせています。これによりAndroid 15未満でも初回描画からedge-to-edgeが有効になり、setContent後に呼んでいた旧実装で懸念された初期layoutのjump/flashを避けています。
2. **DEFAULT/LIGHT/DARK切り替え時のicon appearance同期**: `setContent` 内で `useDarkTheme`(算出ロジックは変更なし)を key にした `SideEffect` から、`WindowCompat.getInsetsController(window, window.decorView)` の `isAppearanceLightStatusBars` / `isAppearanceLightNavigationBars` を更新。同じ公式ガイドに記載の `WindowInsetsControllerCompat` を使った切り替え方法をそのまま採用しています。deprecatedな `window.statusBarColor` 直接代入や `systemUiVisibility` は使用していません。

### API 26〜28固有の対応(追加レビュー反映)

`enableEdgeToEdge()` を引数なしで呼ぶ場合、`navigationBarStyle` の既定値は `SystemBarStyle.auto(DefaultLightScrim, DefaultDarkScrim)` です。このscrim色を選ぶ `detectDarkMode` の既定実装は `Resources.configuration.uiMode`(**OS側**のdark/light)だけを見ており、DAIgoAPP独自のDEFAULT/LIGHT/DARK(`useDarkTheme`)は一切参照しません。AndroidX Activity 1.13.0のソース(`EdgeToEdge.kt` / `EdgeToEdgeApi26`)で、API 29未満は

```kotlin
window.navigationBarColor = navigationBarStyle.getScrim(navigationBarIsDark)
```

としてscrim色を直接windowへ設定していることを確認しました(API 29以上は `EdgeToEdgeApi29` が別途 `getScrimWithEnforcedContrast` を使い、night modeが `AUTO` なら常にTRANSPARENTになるため元々影響を受けません)。そのため、例えば「OS = Light」かつ「DAIgoAPP = DARK」のような組み合わせでは、API 26〜28でnavigation bar背景だけがOS Light用のscrim(白っぽい半透明)になり、`SideEffect` で同期しているicon appearance(DARK theme相当の明るいicon)と矛盾してコントラストが崩れることが分かりました。

対応として、`enableEdgeToEdge()` の `navigationBarStyle` を `SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT)` に固定しました。DAIgoAPPはSurface自体がSystem Bar領域までアプリthemeのbackgroundを描画しているため、API 26〜28でもscrimを持たせず透明にすることで、常にアプリ自身の背景がそのまま見える(=どのAPIレベルでも `useDarkTheme` と一致する)構成にしています。`statusBarStyle` は既定値のままで問題ないため変更していません。`window.navigationBarColor` を直接操作する独自実装や、API level分岐の追加は行っていません。

## WindowInsetsをどう整理したか

- `Surface` からは `.windowInsetsPadding(WindowInsets.systemBars)` を外し、`Modifier.fillMaxSize()` のみとして、Surfaceの背景色(`MaterialTheme.colors.background`)がSystem Bar領域も含め画面全体に描画されるようにしました。
- Surfaceの直下に新設した `Box` へ、既存のdialog群・`ModalBottomSheetLayout`・`AllViews` をそのまま移動し、対話可能なコンテンツ側だけがsystem barとdisplay cutoutの両方を避けるようにしました。
- (レビュー指摘反映)Boxのinsetは `WindowInsets.systemBars.union(WindowInsets.displayCutout)` としました。`WindowInsets.Companion.safeDrawing` は `systemBars.union(ime).union(displayCutout)`(androidx.compose.foundation.layout の実装ソースで確認)でIME insetを含むため、今回IMEの挙動を変更しない方針と合わず不採用としました。`union()` は `androidx.compose.foundation.layout` の安定APIです。
- status bar高さやcutout位置等の固定dp値は使用していません。`WindowInsets` による動的なinset解決のみです。

## 上部spacingの変更内容

前回PRから変更していません。`AllViews` 内、`SamplesCompose` / `InputCompose` をまとめている `Column` に `Modifier.padding(top = 8.dp)` を追加した状態を維持しています(既存の `SamplesCompose` 自身の16.dp paddingと合わせ、System Bar inset + 8.dp + 16.dp ≒ 24.dpの自然な上部余白)。display cutout対応後に実機・emulatorで再確認しましたが、二重paddingや過剰な余白は見られなかったため、追加の調整は行っていません。広告を模したPlaceholderや固定の大きな空白は追加していません。

## DEFAULT / LIGHT / DARKへの対応方法

`useDarkTheme` の算出ロジック自体は変更しておらず(`DEFAULT`→`isSystemInDarkTheme()`、`LIGHT`→`false`、`DARK`→`true`)、この値を `AppTheme` とSystem Bar appearance同期用の `SideEffect` の両方に渡すことで、Compose colorとSystem Bar appearanceが常に同じ判定基準で切り替わるようにしています。

## 変更ファイル一覧

- `app/src/main/java/net/ambitious/daigoapp/android/MainActivity.kt`

## 検証結果

- `./gradlew :app:assembleDebug` → BUILD SUCCESSFUL
- `./gradlew :app:testDebugUnitTest` → BUILD SUCCESSFUL
- `git diff --check` → 問題なし
- PR CI → SUCCESS(instrumentation testを含め全ステップ成功。最新コミットでのCI結果はPRのChecksタブを参照)

## 実機 / emulatorでのUI確認結果

以下の端末で debug ビルドを実際に起動して確認しました。

- 実機: Pixel 3a XL (Android 12 / API 32、targetSdk未満のOSでedge-to-edgeが自動強制されない環境。`enableEdgeToEdge()` の明示呼び出しが効いているかを確認する上で重要)
- phone emulator: Android 16 (API 36、sdk_gphone64_arm64。targetSdk 37相当でedge-to-edge強制環境)
- phone emulator: Android 9 (API 28、arm64-v8a。今回のnavigationBarStyle修正が必要になるAPIレベルの上限。ローカルにAVDが無かったため `sdkmanager` で `system-images;android-28;google_apis;arm64-v8a` を取得し新規作成)

確認したパターンと結果(API 32 / 36端末):

- LIGHT: status barの時刻・iconが黒ではっきり読める。status bar背景とアプリ背景が分断されない。
- DARK: status barが黒背景・白文字/iconとなり、アプリのダーク背景と自然に連続する。
- DEFAULT + OS light(emulator): LIGHT相当の見た目で正しく追従。
- DEFAULT + OS dark(emulator): DARK相当の見た目で正しく追従。
- アプリ内theme切り替え(DEFAULT/LIGHT/DARK)後、即座にSystem Bar appearanceが追従することを確認しました。
- DARK設定でアプリを強制終了→再起動し、起動直後のフレームでもstatus bar/contentの不自然なjumpや、明るい背景が一瞬見えるようなflashが無いことを確認しました(Android標準のSplashScreen API自体の背景色はOS light/dark設定に依存し本Issueのスコープ外です)。
- サンプル語チップ群が上端へ詰まりすぎず、生成ボタン・input・menuの位置関係も崩れていないことを確認しました。
- ModalBottomSheetLayoutを開閉して、既存のMenuCompose(DEFAULT/LIGHT/DARK切り替えを含む)・BottomSheetの表示に問題がないことを確認しました。

確認したパターンと結果(API 28、navigationBarStyle修正の検証):

- OS Light + アプリLIGHT / OS Dark + アプリDARK(OSとアプリのthemeが一致する組み合わせ)は元々問題なし。
- **OS Light + アプリDARK / OS Dark + アプリLIGHT**(OSとアプリのthemeが食い違う組み合わせ)で、修正前のコード(このPRの直前のコミット)ではnavigation bar領域だけ灰色のscrimがかかりアプリ背景から明確に分断されることを実機画面で確認しました。修正後のコードでは同じ組み合わせでnavigation bar背景が透過してアプリ自身のbackgroundと連続し、iconのコントラストも保たれることを確認しました。
- 4パターンいずれもstatus barは元々問題なく(status barStyleは変更していないため)、navigation barのみ改善を確認しました。

なお、画面最下部にBottomSheetの内容がごく僅かに覗く既存の見た目は、修正前のmainブランチでも同一条件で再現することを確認済みで、本Issue・本PRのスコープ外として変更していません。

## display cutout確認結果

手元の実機・emulatorともdisplay cutout(notch / punch-hole)を持たない機種のため、cutoutへコンテンツが侵入しないことの実機上での直接確認はできていません。`WindowInsets.systemBars.union(WindowInsets.displayCutout)` の採用と、固定dp値を使わない実装であることはコードおよびAPI仕様(androidx.compose.foundation.layout の `WindowInsets.android.kt` ソースで `displayCutout` / `union` の定義を確認済み)で担保しています。横画面またはcutout付きemulatorでの実機確認は未実施です。

## スクリーンショットの有無

実機・emulator双方でLIGHT/DARK/DEFAULT各パターンのスクリーンショットを取得済みですが、本セッションの権限設定により外部ホスティングサービス(Gist等)へのアップロードが許可されず、PR本文への画像添付はできませんでした。必要であればローカルファイルを別途共有します。

## dependency追加の有無

ありません。`androidx.activity`(enableEdgeToEdge)、`androidx.compose.foundation.layout`(WindowInsets union / displayCutout)、`androidx.core.view`(WindowCompat / WindowInsetsControllerCompat)はいずれも既存依存(activity-compose / compose-bom / core-ktx)から解決される既存APIです。

## versionCode / versionName / merge / release

- versionCode / versionNameは変更していません。
- 本PRはmerge / releaseしていません。auto-mergeも設定していません。

## 未検証事項

- `./gradlew :app:connectedCheck` はローカルで未実施です(Issue本文の必須検証項目には含まれていないため)。PR CI上のinstrumentation testの結果をご確認ください。
- display cutout付き端末/emulatorでの実機確認は未実施です(上記「display cutout確認結果」参照)。
- API 26 / 27実機・emulatorでの直接確認は未実施です。ソース上 `EdgeToEdgeApi26` はAPI 26〜28で共通の実装(`EdgeToEdgeApi28` は `EdgeToEdgeApi26` を継承し `setUp` をoverrideしていない)であることを確認済みで、API 28で確認した挙動と同一になるはずですが、実機での動作確認はAPI 28のみです。
- 本Issueで要求されていないため、Material3移行やUIデザインの大幅刷新は行っていません。
- Wear OS emulator (emulator-5554) は本アプリの対象外端末のため検証対象から除外しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
