### PR TITLE
広告IDを使用しない構成へ変更する

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,16 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <uses-permission
+        android:name="com.google.android.gms.permission.AD_ID"
+        tools:node="remove" />
+    <uses-permission
+        android:name="android.permission.ACCESS_ADSERVICES_AD_ID"
+        tools:node="remove" />
+    <uses-permission
+        android:name="android.permission.ACCESS_ADSERVICES_ATTRIBUTION"
+        tools:node="remove" />
+
     <application
         android:allowBackup="false"
         android:supportsRtl="true"
@@ -12,6 +22,9 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         tools:ignore="DataExtractionRules">
+        <meta-data
+            android:name="google_analytics_adid_collection_enabled"
+            android:value="false" />
         <activity
             android:name=".MainActivity"
             android:exported="true">


### PR DESCRIPTION
Closes #188

## 目的

DAIgoAPPは1.0.4でAdMobを削除済みで広告表示は行っていないが、releaseのMerged Manifestには依然としてFirebase Analytics（play-services-measurement系）由来の広告ID関連permissionが混入していた。これをアプリ側で明示的に除去し、広告IDを使用しない構成であることをManifest/設定上も明確にする。

## 変更内容

`app/src/main/AndroidManifest.xml` に以下を追加。

- `com.google.android.gms.permission.AD_ID` を `tools:node="remove"` で除去
- `android.permission.ACCESS_ADSERVICES_AD_ID` を `tools:node="remove"` で除去
- `android.permission.ACCESS_ADSERVICES_ATTRIBUTION` を `tools:node="remove"` で除去
- `google_analytics_adid_collection_enabled` を `false` に設定し、Firebase Analyticsの広告ID収集を明示的に無効化

Firebase Analytics / Crashlytics自体の依存構成は変更していない。AdMobの再導入は行っていない。

### 実装前の調査で判明した事項（PRレビュー向け補足）

Issue本文が明示していた `com.google.android.gms.permission.AD_ID` に加えて、実際にreleaseのMerged Manifestを生成したところ、同じくFirebase Analytics実装（`com.google.android.gms:play-services-measurement*`）由来の `ACCESS_ADSERVICES_AD_ID` / `ACCESS_ADSERVICES_ATTRIBUTION`（Android 13+ Privacy Sandbox AdServices向けpermission）も混入していることを確認した。これらもIssueの目的（広告IDを使用しない構成へ変更する）に合致するため、リポジトリオーナーに確認の上、3つとも除去する方針とした。

Firebase公式ドキュメント（[Configure Analytics data collection](https://firebase.google.com/docs/analytics/android/configure-data-collection)）には `google_analytics_adid_collection_enabled` の指定方法のみが記載されており、Manifestからのpermission除去自体は公式手順としての明記はない。Issue本文で提示されていた `tools:node="remove"` によるpermission除去は広く使われている手法であり、今回の変更でも実際にreleaseのMerged Manifest / bundle manifestから3つとも消えることを確認済み。

## 検証結果

- `./gradlew :app:assembleDebug` : 成功
- `./gradlew :app:testDebugUnitTest` : 成功
- `./gradlew :app:processReleaseMainManifest` : 成功。生成された `app/build/intermediates/merged_manifest/release/processReleaseMainManifest/AndroidManifest.xml` に `AD_ID` / `ACCESS_ADSERVICES_AD_ID` / `ACCESS_ADSERVICES_ATTRIBUTION` が存在しないことを確認
- `./gradlew :app:processApplicationManifestReleaseForBundle` : 成功。bundle manifestでも同様に3つのpermissionが存在しないことを確認
- manifest merger blame report（`app/build/intermediates/manifest_merge_blame_file/release/processReleaseMainManifest/manifest-merger-blame-release-report.txt`）でも3つのpermissionへの言及が消えていることを確認
- `git diff --check` : 問題なし
- 上記以外のManifest差分がないことをdiffで確認（追加した `tools:node="remove"` の3行と `meta-data` の1ブロックのみ）

## 未検証事項

- `./gradlew :app:connectedCheck` は未実施。ローカル環境にWear OSエミュレーター（`sdk_gwear_arm64`）が同時接続されており、AGENTS.mdの方針に従い対象外端末による失敗を避けるため見送った。今回の変更はManifestのpermission定義のみでアプリの実行時コードに変更はなく、PR CIのAndroid instrumentation testで検証される想定。
- release署名済みAAB (`bundleRelease`) のビルドは未実施（実secrets/signing環境が必要なため）。bundle manifestのみ`processApplicationManifestReleaseForBundle`で検証済み。
- Google Play Consoleの「広告ID」申告変更は、Issue記載の通り本PRのマージ・リリース後に別途対応が必要（本PRの対象外）。
- プライバシーポリシー / Data safetyの記載への影響有無は未確認（本PRの対象外、必要に応じて別途対応）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)