### PR TITLE
Firebase Analytics / Crashlyticsを撤去

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -32,9 +32,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Set config files
-        run: echo ${{ secrets.DEBUG_GOOGLE_SERVICES_JSON }} | base64 -d > app/src/debug/google-services.json
-
       - name: Run Android debug build
         run: ./gradlew :app:assembleDebug
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,6 @@ on:
     types: [published]
 
 env:
-  GOOGLE_SERVICES_JSON: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON_64 }}
   KEYSTORE_ALIAS: ${{ secrets.ANDROID_KEYSTORE_ALIAS }}
   KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
   HOST: ${{ secrets.HOST }}
@@ -30,9 +29,6 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', 'gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-
-      - name: Set config files
-        run: echo $GOOGLE_SERVICES_JSON | base64 -d > app/src/release/google-services.json
 
       - name: Run Build
         run: ./gradlew bundleRelease

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,5 @@
 .externalNativeBuild
 .cxx
 local.properties
-google-services.json
 google-play-service.json
 .envrc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,6 @@ DAIgoAPPはAndroidスマートフォン専用アプリで、application module�
 - Jetpack Compose
 - Retrofit / OkHttp / kotlinx.serialization
 - Room / DataStore
-- Firebase Analytics / Firebase Crashlytics
 - Java 17、リポジトリ同梱のGradle Wrapper
 
 backendは [bvlion/DAIgoAPI2](https://github.com/bvlion/DAIgoAPI2) です。
@@ -19,7 +18,7 @@ backendは [bvlion/DAIgoAPI2](https://github.com/bvlion/DAIgoAPI2) です。
 - 挙動を推測だけで変更せず、既存の実装・呼び出し元・テスト・GitHub Actions workflowを確認してください。
 - DAIgoAPPの規模に対して不要なlayer / abstractionを追加しないでください。
 - Android専用構成のため、明示的な要件がない限りKMP / iOS構成を再導入しないでください。
-- AdMob / Google Mobile Ads SDK、Firebase App Distributionは撤去済みです。「以前あったから」という理由で再導入しないでください。
+- AdMob / Google Mobile Ads SDK、Firebase App Distribution、Firebase Analytics / Firebase Crashlyticsは撤去済みです。「以前あったから」という理由で再導入しないでください。
 
 ## コーディング / 依存管理
 
@@ -45,7 +44,7 @@ DAIgoAPPはスマートフォン専用です。ローカル環境にWear OS emul
 ## 秘密情報とローカル設定
 
 - 新しい秘密値・API token・password・service account JSONをコミットしないでください。
-- `google-services.json` / `google-play-service.json` / `.envrc` は既存の`.gitignore`の扱いを維持してください。
+- `google-play-service.json` / `.envrc` は既存の`.gitignore`の扱いを維持してください。
 - 必要な秘密情報が環境にない場合、ダミー値のコミットや設定の迂回でbuildを通さず、未検証として報告してください。
 - release signingの検証に必要な環境がない場合は未検証として報告してください。
 - `release.keystore` は既にリポジトリで管理されている署名ファイルです。明示的な依頼がない限り削除・置換・ローテーションしないでください。

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ release buildは署名用環境変数と後述の`release.keystore`が必要な�
 
 以下はリポジトリに含めず、各自の環境で用意します（`.gitignore`で除外済み）。
 
-* `google-services.json`
 * `google-play-service.json`
 * `.envrc`（ローカルの`HOST` / `BEARER`等）
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
   alias(libs.plugins.kotlin.compose)
   alias(libs.plugins.kotlin.serialization)
   alias(libs.plugins.ksp)
-  alias(libs.plugins.google.services)
-  alias(libs.plugins.firebase.crashlytics)
   alias(libs.plugins.play.publisher)
 }
 
@@ -86,10 +84,6 @@ dependencies {
   ksp(libs.androidx.room.compiler)
 
   implementation(libs.androidx.activity.compose)
-
-  implementation(platform(libs.firebase.bom))
-  implementation(libs.firebase.crashlytics)
-  implementation(libs.firebase.analytics)
 
   testImplementation(libs.junit)
   testImplementation(platform(libs.okhttp.bom))

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,16 +4,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <uses-permission
-        android:name="com.google.android.gms.permission.AD_ID"
-        tools:node="remove" />
-    <uses-permission
-        android:name="android.permission.ACCESS_ADSERVICES_AD_ID"
-        tools:node="remove" />
-    <uses-permission
-        android:name="android.permission.ACCESS_ADSERVICES_ATTRIBUTION"
-        tools:node="remove" />
-
     <application
         android:allowBackup="false"
         android:supportsRtl="true"
@@ -22,9 +12,6 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         tools:ignore="DataExtractionRules">
-        <meta-data
-            android:name="google_analytics_adid_collection_enabled"
-            android:value="false" />
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,5 @@ plugins {
   alias(libs.plugins.kotlin.compose) apply false
   alias(libs.plugins.kotlin.serialization) apply false
   alias(libs.plugins.ksp) apply false
-  alias(libs.plugins.google.services) apply false
-  alias(libs.plugins.firebase.crashlytics) apply false
   alias(libs.plugins.play.publisher) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,9 +9,6 @@ androidxDatastorePreferences = "1.1.7"
 androidxRoom = "2.8.4"
 composeBom = "2026.06.01"
 
-firebaseBom = "34.17.0"
-googleServices = "4.5.0"
-firebaseCrashlyticsGradle = "3.0.7"
 tripletPlay = "4.1.0"
 
 ksp = "2.3.11"
@@ -39,10 +36,6 @@ androidx-compose-material = { group = "androidx.compose.material", name = "mater
 androidx-compose-material-icons-core = { group = "androidx.compose.material", name = "material-icons-core" }
 androidx-compose-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata" }
 
-firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
-firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
-firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
-
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 
@@ -59,6 +52,4 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
-google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
-firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsGradle" }
 play-publisher = { id = "com.github.triplet.play", version.ref = "tripletPlay" }


### PR DESCRIPTION
## 目的

Closes #195

現在ほぼ利用していない Firebase Analytics / Firebase Crashlytics を「無効化」ではなく撤去し、DAIgoAPPからデータ収集を行わない構成にする。あわせて `google-services.json` を必要としないbuild / CI構成にする。

対象外の後続作業（DAIgoAPI2側プライバシーポリシー更新、Google Play Data safety変更、Firebase Console / GitHub Secrets後片付け）は #196 / DAIgoAPI2#71 に分離済みで、本PRでは実施しない。

## 変更内容

### Gradle / dependency
- `app/build.gradle.kts`: Google Services plugin、Firebase Crashlytics plugin、Firebase BOM、`firebase-analytics`、`firebase-crashlytics`を削除
- root `build.gradle.kts`: Google Services / Firebase Crashlytics plugin aliasを削除
- `gradle/libs.versions.toml`: Firebase BOM / Analytics / Crashlytics / Google Services plugin / Firebase Crashlytics plugin のversion・library・plugin定義を削除（repository内で他用途に使われていないことを確認済み）

### Manifest
`app/src/main/AndroidManifest.xml` から以下を削除。

- `com.google.android.gms.permission.AD_ID` / `android.permission.ACCESS_ADSERVICES_AD_ID` / `android.permission.ACCESS_ADSERVICES_ATTRIBUTION` の `tools:node="remove"`（Firebase撤去によりdependency側からmergeされなくなったため不要と確認）
- `google_analytics_adid_collection_enabled=false` のmeta-data

### GitHub Actions
- `.github/workflows/pr-ci.yaml`: `DEBUG_GOOGLE_SERVICES_JSON` から `app/src/debug/google-services.json` を生成するstepを削除
- `.github/workflows/release.yaml`: `ANDROID_GOOGLE_SERVICES_JSON_64` のenv定義と `app/src/release/google-services.json` を生成するstepを削除
- Google Play Publisher用の `GOOGLE_PLAY_SERVICE_JSON` / `google-play-service.json` / `publishBundle` / `publishListing` / `listing.yaml` は変更なし

### その他
- `.gitignore`: `google-services.json` のignoreを削除（他用途なしを確認）
- `AGENTS.md` / `README.md`: Firebase Analytics / Crashlytics関連の記載を実態に合わせて更新

## 検証結果

- `./gradlew :app:assembleDebug` — 成功（ローカルの `app/src/debug`・`app/src/release` の `google-services.json` を一時退避し、`google-services.json`が存在しない状態でdebug buildできることを確認）
- `./gradlew :app:testDebugUnitTest` — 成功
- `git diff --check` — 差分なし
- `./gradlew bundleRelease` — 成功（ローカルの署名 / `HOST` / `BEARER` 環境変数で実行可能な状態だったため実施。`google-services.json`なしでrelease bundleも生成できることを確認）
- `./gradlew :app:dependencies --configuration releaseRuntimeClasspath` — `firebase` を含む依存が0件であることを確認
- Merged Manifest確認
  - debug: `app/build/intermediates/merged_manifests/debug/.../AndroidManifest.xml` にAD_ID系permission・Firebase由来component/metadataなし
  - release: 一度stale（Firebase込みの旧ビルド）成果物が残っていたため `processReleaseManifestForPackage` 等を再実行し最新化。AD_ID系permission・Firebase由来component/metadataなしを確認
- 実際に生成した `app-release.aab` を展開し、`base/manifest/AndroidManifest.xml`（protobuf形式）をバイナリレベルでgrepし、`firebase` / `AD_ID` / `ADSERVICES` / `crashlytics` / `google_analytics` の文字列が一切含まれないことを確認
- `app-release.aab` 内のファイル一覧にも `firebase` / `crashlytics` を含むエントリが存在しないことを確認
- Google Play Publisher関連処理（`play { }` ブロック、`publishBundle` / `publishListing` step）は無変更

## 未実施事項

- `./gradlew :app:connectedCheck`（instrumentation test）: UI変更を含まない差分のため、Issue本文の指示に従い未実施
- DAIgoAPI2側プライバシーポリシー更新: 別Issue（DAIgoAPI2#71）で対応予定。Firebase-free版がproductionへ反映された後に実施が必要
- Google Play Data safetyの変更: 別Issue（#196）で対応予定。現在productionのv1.0.6にはFirebaseが含まれているため本PRでは先行変更しない
- Firebase Console上のAndroid app登録削除 / project削除、GitHub Actions Secrets（`DEBUG_GOOGLE_SERVICES_JSON` / `ANDROID_GOOGLE_SERVICES_JSON_64`）の削除: #196で対応予定
- versionCode / versionName変更、tag / GitHub Release作成、Google Playへのproductionリリース: 本PRの対象外