### PR TITLE
ご意見リンクを共通問い合わせURLへ切り替え

### DIFF
--- a/app/src/main/java/net/ambitious/daigoapp/android/compose/MenuCompose.kt
+++ b/app/src/main/java/net/ambitious/daigoapp/android/compose/MenuCompose.kt
@@ -131,7 +131,7 @@ fun MenuCompose(
         .align(Alignment.Start),
       onClick = {
         context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(
-          "https://docs.google.com/forms/d/e/1FAIpQLSecLnJGQu3C-24UMTcji_jnt7kRqgtTjQglKyA8xu6ILdnrDQ/viewform"
+          "https://contact.ambitious-i.net/ryakugo-generator"
         )))
       }
     ) {


### PR DESCRIPTION
## 概要

Closes #198

略語Generatorの「ご意見」押下時に開くURLを、旧Google Formの直接URLから共通問い合わせURLへ切り替える。

## 変更内容

- `app/src/main/java/net/ambitious/daigoapp/android/compose/MenuCompose.kt` の「ご意見」ボタンで開くURLを `https://contact.ambitious-i.net/ryakugo-generator` に変更
- URL文字列の変更のみ。定数抽出・レイヤー追加・リファクタリング・整形は行っていない

## 検証結果

- `git diff --check`: 問題なし
- `./gradlew :app:assembleDebug`: BUILD SUCCESSFUL

## 未検証事項

- `contact.ambitious-i.net` は現在DNS / サブドメイン反映待ちのため、実機・エミュレーターでの実URL遷移確認（リンク先が実際に開くか）は未実施。反映後に動作確認が必要。
- 上記の理由により、動作確認が完了するまで本PRはmergeしないでください。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>